### PR TITLE
bug: Removed `/api/` and fixed certain warn logging statements being fired when not needed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,7 @@ client = LinkedRolesOAuth2(
     client_secret='client_secret',
     redirect_uri='http://localhost:8000/verified-role',
     # token='discord_token',
-    scopes=('role_connection_write', 'identify'),
-    state='cookie_secret'
+    scopes=('role_connections.write', 'identify'),
 )
 
 @app.on_event('startup')

--- a/linked_roles/http.py
+++ b/linked_roles/http.py
@@ -132,10 +132,10 @@ class HTTPClient:
         proxy_auth: Optional[aiohttp.BasicAuth] = None,
         token: Optional[str] = None,
     ) -> None:
-        if OAuth2Scopes.identify not in scopes:
-            _log.warning('You must specify the identify scope.')
-        if OAuth2Scopes.role_connection_write not in scopes:
-            _log.warning('You must specify the role_connection_write scope.')
+        if OAuth2Scopes.identify.value not in scopes:
+            _log.warning(f'You must specify the {OAuth2Scopes.identify.value} scope.')
+        if OAuth2Scopes.role_connection_write.value not in scopes:
+            _log.warning(f'You must specify the {OAuth2Scopes.role_connection_write.value} scope.')
         self.loop: asyncio.AbstractEventLoop = loop
         self.client_id = client_id
         self.client_secret = client_secret
@@ -210,7 +210,7 @@ class HTTPClient:
 
     def get_oauth_url(self) -> str:
         state = self.state or uuid.uuid4().hex
-        url = 'https://discord.com/api/oauth2/authorize'
+        url = 'https://discord.com/oauth2/authorize'
         params = {
             'client_id': self.client_id,
             'redirect_uri': self.redirect_uri,


### PR DESCRIPTION
Future commits that need to be made to get this repro up to spec;
1. Unique `state` url params per user; this is a safety feature that is lacking at the moment.

`/api` was removed from the linked-roles auth URI as it sends users to the wrong page;
![image](https://github.com/staciax/discord-linked-roles/assets/57773965/66cb0d79-c07d-40cd-93f0-4efb890c00c4)
